### PR TITLE
[Core] Add input / output / bioindex option with subdirectories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val Versions = new {
   val ScalaLogging     = "3.9.2"
   val ScalaTest        = "3.1.2"
   val Scallop          = "3.5.0"
-  val DigAws           = "0.3.2-SNAPSHOT"
+  val DigAws           = "0.3.3-SNAPSHOT"
 }
 
 lazy val Orgs = new {

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Context.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Context.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dig.aggregator.core
 
 import org.broadinstitute.dig.aws.Emr
 import org.broadinstitute.dig.aws.S3
+import org.broadinstitute.dig.aws.config.RdsConfig
 
 /** Method execution context. */
 abstract class Context(val method: Method, val config: Option[Config]) {
@@ -9,8 +10,17 @@ abstract class Context(val method: Method, val config: Option[Config]) {
   /** Override to provide a valid database connection. */
   lazy val db: Db = throw new NotImplementedError("No DB defined in context!")
 
-  /** Override to provide a valid S3 bucket. */
-  lazy val s3: S3.Bucket = throw new NotImplementedError("No S3 client in context!")
+  /** Override to provide a valid database connection. */
+  lazy val portal: RdsConfig = throw new NotImplementedError("No portal Config defined in context!")
+
+  /** Override to provide a valid S3 input bucket. */
+  lazy val s3: S3.Bucket = throw new NotImplementedError("No S3 input in context!")
+
+  /** Override to provide a valid S3 output bucket. */
+  lazy val s3Output: S3.Bucket = throw new NotImplementedError("No S3 output in context!")
+
+  /** Override to provide a valid S3 bioindex bucket. */
+  lazy val s3Bioindex: S3.Bucket = throw new NotImplementedError("No S3 bioindex in context!")
 
   /** Override to provide a valid EMR job runner. */
   lazy val emr: Emr.Runner = throw new NotImplementedError("No EMR client in context!")

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
@@ -119,8 +119,13 @@ abstract class Stage(implicit context: Context) extends LazyLogging {
        * For PySpark steps, this is done using the yarn-env configuration.
        * Scripts can also access the environment using `yarn` command.
        */
-      var env = Map(
+      var env: Map[String, String] = Map(
         "JOB_BUCKET" -> s"s3://${context.s3.bucket}",
+        "INPUT_PATH" -> s"s3://${context.s3.path}",
+        "OUTPUT_PATH" -> s"s3://${context.s3Output.path}",
+        "BIOINDEX_PATH" -> s"s3://${context.s3Bioindex.path}",
+        "PORTAL_SECRET" -> context.config.get.aws.portal.instance,
+        "PORTAL_DB" -> context.portal.secret.get.dbname,
         "JOB_METHOD" -> context.method.getName,
         "JOB_STAGE"  -> getName,
         "JOB_PREFIX" -> s"$prefix/${context.method.getName}/$getName"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2-SNAPSHOT"
+version in ThisBuild := "0.3.3-SNAPSHOT"


### PR DESCRIPTION
Same as dig-aws#15 except in core. Sets and passes through the new envvars for private portals