### PR TITLE
Add project and Runs Status table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val Versions = new {
   val ScalaLogging     = "3.9.2"
   val ScalaTest        = "3.1.2"
   val Scallop          = "3.5.0"
-  val DigAws           = "0.3.3-SNAPSHOT"
+  val DigAws           = "0.3.4-SNAPSHOT"
 }
 
 lazy val Orgs = new {

--- a/src/main/resources/runs.sql
+++ b/src/main/resources/runs.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS `runs` (
     `id` INT NOT NULL AUTO_INCREMENT,
+    `project` VARCHAR(200) NOT NULL,
     `method` VARCHAR(200) NOT NULL,
     `stage` VARCHAR(200) NOT NULL,
     `input` VARCHAR(1024) NOT NULL,
@@ -7,5 +8,5 @@ CREATE TABLE IF NOT EXISTS `runs` (
     `output` VARCHAR(200) NOT NULL,
     `timestamp` DATETIME NOT NULL DEFAULT NOW(),
     PRIMARY KEY (`id`),
-    UNIQUE INDEX `stage_IDX` (`method` ASC, `stage` ASC, `input` ASC, `output` ASC)
+    UNIQUE INDEX `stage_IDX` (`project` ASC, `method` ASC, `stage` ASC, `input` ASC, `output` ASC)
 )

--- a/src/main/resources/runs.sql
+++ b/src/main/resources/runs.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS `runs` (
     `id` INT NOT NULL AUTO_INCREMENT,
-    `project` VARCHAR(200) NOT NULL,
-    `method` VARCHAR(200) NOT NULL,
-    `stage` VARCHAR(200) NOT NULL,
-    `input` VARCHAR(1024) NOT NULL,
+    `project` VARCHAR(50) NOT NULL,
+    `method` VARCHAR(50) NOT NULL,
+    `stage` VARCHAR(50) NOT NULL,
+    `input` VARCHAR(250) NOT NULL,
     `version` DATETIME NOT NULL,
-    `output` VARCHAR(200) NOT NULL,
+    `output` VARCHAR(250) NOT NULL,
     `timestamp` DATETIME NOT NULL DEFAULT NOW(),
     PRIMARY KEY (`id`),
     UNIQUE INDEX `stage_IDX` (`project` ASC, `method` ASC, `stage` ASC, `input` ASC, `output` ASC)

--- a/src/main/resources/runstatus.sql
+++ b/src/main/resources/runstatus.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS `runstatus` (
     `id` INT NOT NULL AUTO_INCREMENT,
-    `project` VARCHAR(200) NOT NULL,
-    `method` VARCHAR(200) NOT NULL,
-    `stage` VARCHAR(200) NOT NULL,
-    `output` VARCHAR(200) NOT NULL,
+    `project` VARCHAR(50) NOT NULL,
+    `method` VARCHAR(50) NOT NULL,
+    `stage` VARCHAR(50) NOT NULL,
+    `output` VARCHAR(250) NOT NULL,
     `started` DATETIME,
     `ended` DATETIME,
     `created` DATETIME NOT NULL DEFAULT NOW(),

--- a/src/main/resources/runstatus.sql
+++ b/src/main/resources/runstatus.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `runstatus` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `project` VARCHAR(200) NOT NULL,
+    `method` VARCHAR(200) NOT NULL,
+    `stage` VARCHAR(200) NOT NULL,
+    `output` VARCHAR(200) NOT NULL,
+    `started` DATETIME,
+    `ended` DATETIME,
+    `created` DATETIME NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `output_IDX` (`project` ASC, `method` ASC, `stage` ASC, `output` ASC)
+)

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Context.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Context.scala
@@ -7,6 +7,8 @@ import org.broadinstitute.dig.aws.config.RdsConfig
 /** Method execution context. */
 abstract class Context(val method: Method, val config: Option[Config]) {
 
+  lazy val project: String = throw new NotImplementedError("No project defined in context!")
+
   /** Override to provide a valid database connection. */
   lazy val db: Db = throw new NotImplementedError("No DB defined in context!")
 
@@ -29,4 +31,5 @@ abstract class Context(val method: Method, val config: Option[Config]) {
 /** Method execution context for testing. */
 class TestContext(override val method: Method) extends Context(method, None) {
   override lazy val db: Db = new Db()
+  override lazy val project: String = "test"
 }

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Method.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Method.scala
@@ -107,6 +107,7 @@ abstract class Method extends LazyLogging {
 
       // create the execution context
       implicit val context: Context = new Context(this, Option(opts.config)) {
+        override lazy val project: String       = opts.config.aws.project
         override lazy val db: Db                = if (opts.test()) new Db() else new Db(opts.config.aws.runs.secret.get)
         override lazy val portal: RdsConfig     = opts.config.aws.portal
         override lazy val s3: S3.Bucket         = new S3.Bucket(opts.config.aws.input.bucket, opts.config.aws.input.subdir)
@@ -123,6 +124,7 @@ abstract class Method extends LazyLogging {
         // ensure the runs table exists
         logger.info(s"Connecting to ${opts.config.aws.runs.instance}...")
         Runs.migrate()
+        RunStatus.migrate()
 
         // verify the action and execute it
         confirmReprocess(opts) {

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/RunStatus.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/RunStatus.scala
@@ -1,0 +1,129 @@
+package org.broadinstitute.dig.aggregator.core
+
+import com.typesafe.scalalogging.LazyLogging
+
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+import scala.io.Source
+
+case class RunStatus(
+  project: String,
+  method: String,
+  stage: String,
+  output: String,
+  started: Option[LocalDateTime],
+  ended: Option[LocalDateTime],
+  created: LocalDateTime,
+)
+
+object RunStatus extends LazyLogging {
+
+  /** Implicit conversion from Instant -> MySQL. */
+  /** Create the runs table if it doesn't already exist. */
+  def migrate()(implicit context: Context): Unit = {
+    import context.db.ctx._
+
+    // load the create table query
+    val sql = Source.fromResource("runstatus.sql").mkString
+
+    // create the table if it doesn't exist
+    context.db.ctx.run(quote(infix"#$sql".as[Action[Unit]]))
+    ()
+  }
+
+  /** Delete the runs table if it exists. Used for testing. */
+  private[core] def drop()(implicit context: Context): Unit = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote(infix"DROP TABLE IF EXISTS runs_status".as[Action[Unit]]))
+    ()
+  }
+
+  /** Returns a list of all runs in the database. Used for testing. */
+  private[core] def all()(implicit context: Context): List[RunStatus] = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote(query[RunStatus]))
+  }
+
+  /** Delete outputs from the database. */
+  def delete(stage: Stage, output: String)(implicit context: Context): Long = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote {
+      query[RunStatus].filter { r =>
+        r.project == lift(context.project) &&
+          r.method == lift(context.method.getName) &&
+          r.stage == lift(stage.getName) &&
+          r.output == lift(output)
+      }.delete
+    })
+  }
+
+  /** Add outputs to the database with all input versions and provenance data. */
+  def insert(stage: Stage, output: String)(implicit context: Context): Long = {
+    import context.db.ctx._
+
+    // generate runs to insert
+    val runsStatus = RunStatus(
+      context.project,
+      context.method.getName,
+      stage.getName,
+      output,
+      None,
+      None,
+      LocalDateTime.ofInstant(Instant.now, ZoneOffset.UTC)
+    )
+
+    context.db.ctx.run(quote {
+      query[RunStatus].insert(lift(runsStatus))
+        .onConflictUpdate(
+          (tbl, _) => tbl.started -> None,
+          (tbl, _) => tbl.ended -> None,
+          (tbl, values) => tbl.created -> values.created,
+        )
+    })
+  }
+
+  def start(stage: Stage, output: String)(implicit context: Context): Unit = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote {
+      query[RunStatus].filter { r =>
+        r.project == lift(context.project) &&
+          r.method == lift(context.method.getName) &&
+          r.stage == lift(stage.getName) &&
+          r.output == lift(output)
+      }.update {
+        value => value.started -> lift(Option(LocalDateTime.ofInstant(Instant.now, ZoneOffset.UTC)))
+      }
+    })
+  }
+
+  def end(stage: Stage, output: String)(implicit context: Context): Unit = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote {
+      query[RunStatus].filter { r =>
+        r.project == lift(context.project) &&
+          r.method == lift(context.method.getName) &&
+          r.stage == lift(stage.getName) &&
+          r.output == lift(output)
+      }.update {
+        value => value.ended -> lift(Option(LocalDateTime.ofInstant(Instant.now, ZoneOffset.UTC)))
+      }
+    })
+  }
+
+  /** Lookup all the results of the current method's stage. */
+  def of(stage: Stage)(implicit context: Context): Seq[RunStatus] = {
+    import context.db.ctx._
+
+    context.db.ctx.run(quote {
+      query[RunStatus].filter { r =>
+        r.project == lift(context.project) &&
+          r.method == lift(context.method.getName) &&
+          r.stage == lift(stage.getName)
+      }
+    })
+  }
+}

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Runs.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Runs.scala
@@ -17,6 +17,7 @@ import scala.io.Source
   * an instance, multiple records are inserted.
   */
 case class Runs(
+    project: String,
     method: String,
     stage: String,
     input: String,
@@ -64,6 +65,7 @@ object Runs extends LazyLogging {
 
     context.db.ctx.run(quote {
       query[Runs].filter { r =>
+        r.project == lift(context.project) &&
         r.method == lift(context.method.getName) &&
         r.stage == lift(stage.getName) &&
         r.output == lift(output)
@@ -78,6 +80,7 @@ object Runs extends LazyLogging {
     // generate runs to insert
     val runs = inputs.map { input =>
       Runs(
+        context.project,
         context.method.getName,
         stage.getName,
         input.key,
@@ -105,6 +108,7 @@ object Runs extends LazyLogging {
 
     context.db.ctx.run(quote {
       query[Runs].filter { r =>
+        r.project == lift(context.project) &&
         r.method == lift(context.method.getName) &&
         r.stage == lift(stage.getName)
       }

--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
@@ -149,6 +149,8 @@ abstract class Stage(implicit context: Context) extends LazyLogging {
 
       // prepare to run all the jobs
       output.keys.foreach(prepareJob)
+      output.keys.foreach(o => RunStatus.insert(this, o))
+      output.keys.foreach(o => RunStatus.start(this, o))
 
       // spins up the cluster(s) and runs all the jobs
       context.emr.runJobs(clusterCommon, env, jobs.toSeq, maxParallel = opts.maxClusters())
@@ -268,6 +270,7 @@ abstract class Stage(implicit context: Context) extends LazyLogging {
     for ((output, inputs) <- outputs.toList.sortBy(_._1)) {
       logger.info(s"Updating output $output for $getName (${inputs.size} inputs)...")
       Runs.insert(this, output, inputs.toList)
+      RunStatus.end(this, output)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dig/aggregator/core/RunsStatusTest.scala
+++ b/src/test/scala/org/broadinstitute/dig/aggregator/core/RunsStatusTest.scala
@@ -1,0 +1,87 @@
+package org.broadinstitute.dig.aggregator.core
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+import org.scalatest.funsuite.AnyFunSuite
+
+final class RunsStatusTest extends AnyFunSuite {
+  implicit val context: Context = new TestContext(TestMethod)
+
+  // instantiate a stage to use as a test
+  private val testStage = new TestMethod.TestStage()
+
+  test("migrate") {
+    RunStatus.migrate()
+    assert(RunStatus.all().isEmpty)
+  }
+
+  test("insert/delete - single input") {
+    RunStatus.migrate()
+
+    // insert a single run
+    RunStatus.insert(testStage, "o1")
+    assert(RunStatus.all().size == 1)
+
+    // delete run
+    RunStatus.delete(testStage, "o1")
+    assert(RunStatus.all().isEmpty)
+  }
+
+  test("insert/delete") {
+
+    RunStatus.migrate()
+
+    RunStatus.insert(testStage, "o1")
+    RunStatus.insert(testStage, "o2")
+
+    // ensure the inputs match outputs
+    val results = RunStatus.of(testStage)
+
+    // db should only have 6 rows
+    assert(results.size == 2)
+
+    // get the runs of output 1 and 2
+    val o1 = results.filter(_.output == "o1")
+    val o2 = results.filter(_.output == "o2")
+    assert(o1.size == 1)
+    assert(o2.size == 1)
+
+    // delete runs
+    RunStatus.delete(testStage, "o1")
+    RunStatus.delete(testStage, "o2")
+    assert(RunStatus.all().isEmpty)
+  }
+
+  test("update output, removing start / end") {
+    RunStatus.migrate()
+
+    // insert a single output with 3 outputs
+    RunStatus.insert(testStage, "o")
+    val initialOutput = RunStatus.of(testStage).filter(_.output == "o")
+    assert(initialOutput.length == 1)
+    assert(initialOutput.head.started.isEmpty)
+    assert(initialOutput.head.ended.isEmpty)
+    RunStatus.start(testStage, "o")
+    val startedOutput = RunStatus.of(testStage).filter(_.output == "o")
+    assert(startedOutput.length == 1)
+    assert(startedOutput.head.started.isDefined)
+    assert(startedOutput.head.ended.isEmpty)
+    RunStatus.end(testStage, "o")
+    val endedOutput = RunStatus.of(testStage).filter(_.output == "o")
+    assert(endedOutput.length == 1)
+    assert(endedOutput.head.started.isDefined)
+    assert(endedOutput.head.ended.isDefined)
+
+    // running another of the same output should blank out start/end
+    RunStatus.insert(testStage, "o")
+    val updatedOutput = RunStatus.of(testStage).filter(_.output == "o")
+    assert(updatedOutput.length == 1)
+    assert(updatedOutput.head.started.isEmpty)
+    assert(updatedOutput.head.ended.isEmpty)
+
+    // clean up
+    RunStatus.delete(testStage, "o")
+    assert(RunStatus.all().isEmpty)
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.3-SNAPSHOT"
+version in ThisBuild := "0.3.4-SNAPSHOT"


### PR DESCRIPTION
Will allow the tracking of in progress, failed, succeeded jobs in legacy aggregator.

Will need to apply migration to runs table manually. There is no actual migration mechanism here, it just applies a CREATE TABLE IF NOT EXIST. A nuisance but should also fix a prior issue with me creating too large of output fields.