### PR TITLE
Bucket Override, add Project to envvars

### DIFF
--- a/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
+++ b/src/main/scala/org/broadinstitute/dig/aggregator/core/Stage.scala
@@ -128,7 +128,8 @@ abstract class Stage(implicit context: Context) extends LazyLogging {
         "PORTAL_DB" -> context.portal.secret.get.dbname,
         "JOB_METHOD" -> context.method.getName,
         "JOB_STAGE"  -> getName,
-        "JOB_PREFIX" -> s"$prefix/${context.method.getName}/$getName"
+        "JOB_PREFIX" -> s"$prefix/${context.method.getName}/$getName",
+        "PROJECT" -> context.project
       )
 
       // if --test, set the dry run environment variable

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.4-SNAPSHOT"
+version in ThisBuild := "0.3.5-SNAPSHOT"


### PR DESCRIPTION
Allows for the concept of portal vs home project for genetic correlations

Bucket override in principal means going forward we can source data directly from bin, and also the concept of a CMDGA project which runs down to "regions" basically and can be used across projects.